### PR TITLE
fix: default registry mirror #7368

### DIFF
--- a/cmd/skaffold/app/cmd/config/set_test.go
+++ b/cmd/skaffold/app/cmd/config/set_test.go
@@ -415,7 +415,7 @@ func TestGetConfigStructWithIndex(t *testing.T) {
 			description: "survey flag set",
 			cfg:         &config.ContextConfig{},
 			survey:      true,
-			expectedIdx: []int{11},
+			expectedIdx: []int{12},
 		},
 		{
 			description: "no survey flag set",

--- a/pkg/skaffold/config/global_config.go
+++ b/pkg/skaffold/config/global_config.go
@@ -33,6 +33,7 @@ type ContextConfig struct {
 	InsecureRegistries []string `yaml:"insecure-registries,omitempty"`
 	// DebugHelpersRegistry is the registry from which the debug helper images are used.
 	DebugHelpersRegistry string        `yaml:"debug-helpers-registry,omitempty"`
+	RegistryMirror       string        `yaml:"registry-mirror,omitempty"`
 	CacheTag             string        `yaml:"cache-tag,omitempty"`
 	CacheRepo            string        `yaml:"cache-repo,omitempty"`
 	CacheFlags           []string      `yaml:"cache-flags,omitempty"`

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -217,6 +217,19 @@ func GetDebugHelpersRegistry(configFile string) (string, error) {
 	return constants.DefaultDebugHelpersRegistry, nil
 }
 
+func GetRegistryMirror(configFile string) (string, error) {
+	cfg, err := GetConfigForCurrentKubectx(configFile)
+	if err != nil {
+		return "", err
+	}
+
+	if cfg.RegistryMirror != "" {
+		log.Entry(context.TODO()).Infof("Using registry-mirror=%s from config", cfg.RegistryMirror)
+		return cfg.RegistryMirror, nil
+	}
+	return "", nil
+}
+
 func GetCacheTag(configFile string) (string, error) {
 	cfg, err := GetConfigForCurrentKubectx(configFile)
 	if err != nil {

--- a/pkg/skaffold/docker/remote.go
+++ b/pkg/skaffold/docker/remote.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/config"
 	sErrors "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
@@ -145,6 +146,11 @@ func IsInsecure(ref name.Reference, insecureRegistries map[string]bool) bool {
 }
 
 func parseReference(s string, cfg Config, opts ...name.Option) (name.Reference, error) {
+	mirror, _ := config.GetRegistryMirror(cfg.GlobalConfig())
+	if mirror != "" {
+		log.Entry(context.TODO()).Infof("Using default registry = %s for reference parsing", mirror)
+		opts = append(opts, name.WithDefaultRegistry(mirror))
+	}
 	ref, err := name.ParseReference(s, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing reference %q: %w", s, err)

--- a/pkg/skaffold/docker/remote.go
+++ b/pkg/skaffold/docker/remote.go
@@ -19,6 +19,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -146,14 +147,19 @@ func IsInsecure(ref name.Reference, insecureRegistries map[string]bool) bool {
 }
 
 func parseReference(s string, cfg Config, opts ...name.Option) (name.Reference, error) {
+	// if a mirror was configured, use it as the default registry (instead of docker.io):
 	mirror, _ := config.GetRegistryMirror(cfg.GlobalConfig())
 	if mirror != "" {
-		log.Entry(context.TODO()).Infof("Using default registry = %s for reference parsing", mirror)
+		log.Entry(context.TODO()).Debugf("Using default registry = %s as mirror", mirror)
 		opts = append(opts, name.WithDefaultRegistry(mirror))
 	}
 	ref, err := name.ParseReference(s, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing reference %q: %w", s, err)
+	}
+	// if the image was rewritten to use a mirror, warn the user to avoid surprises & troubleshooting:
+	if mirror != "" && ref.Context().Registry.Name() == mirror && !strings.Contains(s, mirror) {
+		log.Entry(context.TODO()).Warnf("Rewrote image ref to use %s registry mirror: %q", mirror, ref)
 	}
 
 	if IsInsecure(ref, cfg.GetInsecureRegistries()) {


### PR DESCRIPTION
<!-- Include if applicable: -->
Fixes: #7368 <!-- tracking issues that this PR will close -->

**Description**

Workaround to avoid Docker Hub pull rate limits.

Skaffold now will parse the name and replace default registry index.docker.io with a configured one.

NOTE: not a full fix as go-containerregistry doesn't support `WithMirror` yet: https://github.com/google/go-containerregistry/issues/1200

**User facing changes**

New global configuration `registry-mirror`, example:
```
skaffold config set registry-mirror mirror.gcr.io
```
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->

Previous log broken build (no mirror):
```
getting hash for artifact "...": getting dependencies for "...": parsing ONBUILD instructions: retrieving image "python:2.7-alpine": GET https://index.docker.io/v2/library/python/manifests/2.7-alpine: TOOMANYREQUESTS: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
```

Log after the fix:
```
time="2025-10-01T19:19:41-05:00" level=trace msg="Checking base image python:2.7-alpine for ONBUILD triggers." subtask=-1 task=DevLoop
time="2025-10-01T19:19:41-05:00" level=info msg="Using registry-mirror=mirror.gcr.io from config" subtask=-1 task=DevLoop
time="2025-10-01T19:19:41-05:00" level=info msg="Using default registry = mirror.gcr.io for reference parsing" subtask=-1 task=DevLoop
...
time="2025-10-01T19:20:09-05:00" level=trace msg="--> GET https://mirror.gcr.io/v2/python/manifests/2.7-alpine"
...
time="2025-10-01T19:20:09-05:00" level=trace msg="<-- 200 https://mirror.gcr.io/v2/python/manifests/2.7-alpine (215.992197ms)"
```

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->

UT coming soon